### PR TITLE
Add comprehensive specs and ADRs for game architecture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# mtg-codenames
+
+A Magic: The Gathering-themed Codenames implementation. This is the glossary for the
+game's domain language — terms specific to this project, not general programming concepts.
+
+## Language
+
+**Player**:
+A participant connected to a room, identified by a server-issued id + secret token (no
+account/credentials). Distinct from a Team's cards.
+_Avoid_: User, account.
+
+**Team**:
+One of the two sides, `mirran` or `phyrexian`. A Player belongs to at most one Team; a
+card's `identity` can also be a Team (meaning that card belongs to that Team).
+
+**Role**:
+A Player's function within their Team: `spymaster` (sees the full key, gives clues) or
+`operative` (guesses cards). Exactly one spymaster per Team; unlimited operatives.
+
+**Agent**:
+A board card belonging to a Team — what operatives are trying to find ("9 agents to
+find"). Not a Player.
+
+**Emrakul**:
+The single instant-loss card identity. If revealed, the guessing Team loses immediately.
+_Avoid_: Assassin (the generic Codenames term — this project always says Emrakul).
+
+**Lobby**:
+The pre-game phase of a room where Players choose their Team and Role before the game
+Starts. Team/Role assignments lock once the game starts (see
+[ADR 0002](./docs/adr/0002-account-less-token-identity.md) and
+[`specs/players-teams-roles.md`](./specs/players-teams-roles.md)).
+
+**Room**:
+An independent game instance, addressed by a short shareable code. See
+[`specs/multi-room.md`](./specs/multi-room.md).

--- a/docs/adr/0001-server-authoritative-redacted-state.md
+++ b/docs/adr/0001-server-authoritative-redacted-state.md
@@ -1,0 +1,16 @@
+# Server-authoritative redacted game state
+
+Today the server broadcasts the full board (every card's true identity) to all clients via
+a single `server.publish('game', ...)`, and the client decides whether to render identities
+based on a `spymasterView` flag/route. This means the key is already present in every
+operative's browser — anyone can open dev tools (or just the spymaster route) and see it.
+
+Once Roles are enforced server-side (see `specs/players-teams-roles.md`), we're rejecting
+the premise that the client can be trusted with secrets it shouldn't have. We decided the
+server must redact unflipped card identities before sending to operatives, and only send
+the full key to the assigned spymaster. This means replacing the single broadcast with
+per-role payloads (two pub/sub topics per room, or per-socket sends) — a real shift in the
+messaging model, but the only way real Codenames secrecy actually exists.
+
+**Consequence:** every place that currently reads `card.identity` on the client must handle
+it being `undefined` for unflipped cards in the operative view.

--- a/docs/adr/0002-account-less-token-identity.md
+++ b/docs/adr/0002-account-less-token-identity.md
@@ -1,0 +1,14 @@
+# Account-less token identity
+
+Players need an identity the server can enforce actions against (which Team/Role they
+hold), and that identity needs to survive a page refresh — but this is a casual,
+no-signup game, so a real account system would be disproportionate.
+
+We chose to have the server mint a `{ playerId, token }` pair on first join, which the
+client persists in `localStorage` and re-presents to reclaim its seat on reconnect. There
+are no credentials, no accounts, and no server-side persistence beyond the running game.
+
+**Trade-off accepted:** anyone who obtains another player's token (e.g. by sharing a
+browser or inspecting `localStorage`) can impersonate them. This is acceptable for a
+casual game among trusted players; it would not be acceptable if this ever needed real
+auth (e.g. ranked play, persistent accounts).

--- a/specs/card-list-selection.md
+++ b/specs/card-list-selection.md
@@ -1,0 +1,331 @@
+# Spec: Card list selection
+
+## Context
+
+Resolves #13, "Add card list selection." Today the server loads exactly one card pool at
+startup (`index.ts:13-15`): `cardlists/mtgo-vintage-cube-nov-2024.txt`, a 540-card
+plain-text file (one name per line — e.g. "Benevolent Bodyguard", "Esper Sentinel").
+`getRandomCards()` (`index.ts:20-29`) draws from this single array; `createNewGame()`
+(`index.ts:33-93`) passes that array in and knows nothing else. A group who wants to play
+with a different cube or set has no option — the list is hardcoded.
+
+This spec adds support for multiple named card lists, each a JSON file in `cardlists/`,
+selectable via a dropdown on the home page at game-creation time. It establishes the file
+format (`{ name, imageUrl }[]`), a server-side whitelist registry, and the extended
+`createNewGame` message that carries a `listId`. It also adds `imageUrl` as a required
+field on `BoardSpace` so the data is available to every downstream consumer without a
+second lookup — this simultaneously lays the foundation for issue #18 (card image view).
+
+Like [`specs/game-logs.md`](./game-logs.md) and [`specs/multi-room.md`](./multi-room.md),
+this spec is written as a buildable increment on today's architecture — see
+[`CONTEXT.md`](../CONTEXT.md) for the Team/Agent/Emrakul glossary used below.
+
+No ADR is needed: the transport, pub/sub topology, and authority model are unchanged. This
+is a format migration on one data file plus small additive changes to an existing message
+and two types.
+
+## Decisions
+
+1. **Format: `.txt` → JSON array.** `cardlists/mtgo-vintage-cube-nov-2024.txt` (and any
+   future list file) becomes a `.json` file whose content is a JSON array of objects:
+   `{ name: string, imageUrl: string }`. URLs are baked into the file at list-authoring
+   time — the Scryfall image URL for each card is looked up once when the list is written
+   and stored statically (e.g.
+   `"https://cards.scryfall.io/normal/front/3/d/3d467e81-....jpg"`). The server never
+   fetches from Scryfall at runtime.
+
+2. **`imageUrl` is required everywhere.** There is no optional/absent-means-no-image path.
+   Every entry in every list file must have a populated `imageUrl`, and `BoardSpace` gains
+   `imageUrl: string` as a required field. This keeps downstream consumers (current and
+   future) free of null checks and conditional rendering branches for the missing-image
+   case.
+
+3. **Whitelist registry in `index.ts`.** A small hardcoded object (`LIST_REGISTRY`) maps
+   each short `listId` string (e.g. `'vintage-cube'`) to a display name and filename. The
+   client sends `listId` in the `createNewGame` message; the server validates it against
+   the registry before touching the filesystem. The server never constructs a path from the
+   raw client string (no `Bun.file('./cardlists/' + parsedMsg.listId)`).
+
+4. **All registered lists are loaded eagerly at startup.** Because list files are small
+   (the existing 540-card file is well under 100 KB as JSON) and the process is
+   long-lived, loading all registered files into a `Map<string, CardEntry[]>` at startup
+   is simpler and faster per request than lazy loading. A per-request JSON parse is
+   unnecessary; per-game, `getRandomCards()` only needs a reference to the
+   already-parsed array.
+
+5. **List chosen at game-creation time.** The home page (`client/src/routes/+page.svelte`)
+   gains a `<select>` dropdown adjacent to the "Create game" button. The selected `listId`
+   is sent in the `createNewGame` WebSocket message. There is no list picker inside the
+   lobby or game view — the choice is made before the game is created, same as today's
+   implicit single-list behavior.
+
+6. **Client hardcodes the registry values — no server round-trip.** The dropdown's option
+   labels and values are the same `listId`/`displayName` pairs from `LIST_REGISTRY`,
+   duplicated client-side as a small literal. The registry is static and changes only with
+   a deploy, so a separate "list available lists" message would add complexity for no gain.
+   If the two copies drift, the server's registry is authoritative (an invalid `listId` is
+   rejected).
+
+7. **Backward-compatible default for missing `listId`.** If a client sends
+   `{ action: 'createNewGame' }` without a `listId` (e.g., old client code during a
+   rolling update), the server falls back to `DEFAULT_LIST_ID` (the designated default
+   entry in `LIST_REGISTRY`) and emits `console.warn`. This avoids breaking an in-flight
+   session during a deploy while still making the field expected going forward.
+
+8. **Invalid `listId` is rejected with `console.error` + `return`.** If `parsedMsg.listId`
+   is a non-null value that does not exist in `LIST_REGISTRY`, the handler logs
+   `console.error` and returns without mutating state — the same pattern used for other
+   validation failures in the file (e.g. `index.ts:208-210` in `handleClueSubmission`,
+   `index.ts:109-111` in `guessCard`). No error message is sent back to the client in this
+   spec (consistent with today's convention; #16's Zod adoption will be the right moment
+   to standardise client-facing error responses).
+
+9. **`CardEntry` lives in `index.ts` as a local type — not exported to the client.** The
+   client only ever sees `BoardSpace` (which now carries `imageUrl`), never the raw list
+   entry. Exporting `CardEntry` from `shared/types.ts` would expose a server-only concern
+   to the client type graph. A one-line `type CardEntry = { name: string; imageUrl: string
+   }` at the top of `index.ts` is sufficient.
+
+10. **`imageUrl` on `BoardSpace` requires no redaction.** Image URLs are not secret: they
+    show the card's face but carry no information about which team that card belongs to
+    (`identity` is what is secret, and remains subject to ADR 0001). Both spymaster and
+    operative views receive `imageUrl` equally; no per-role filtering is needed.
+
+## Domain model — `shared/types.ts`
+
+`BoardSpace` (`shared/types.ts:9-13`) gains one required field:
+
+```ts
+export interface BoardSpace {
+  word: string
+  identity: CardIdentity
+  flipped: boolean
+  imageUrl: string   // new; pre-populated Scryfall image URL
+}
+```
+
+`GameBaseState` (`shared/types.ts:88-96`) is unchanged by this spec.
+
+The raw list entry type is **not** added to `shared/types.ts`. It is a local, server-only
+type in `index.ts` (decision 9):
+
+```ts
+// index.ts, near top — server-only, not exported
+type CardEntry = { name: string; imageUrl: string }
+```
+
+## Backend changes — `index.ts`
+
+### 1. `CardEntry` type, `LIST_REGISTRY`, and eager load (replaces lines 13-15)
+
+```ts
+type CardEntry = { name: string; imageUrl: string }
+
+const LIST_REGISTRY: Record<string, { displayName: string; filename: string }> = {
+  'vintage-cube': {
+    displayName: 'MTGO Vintage Cube (Nov 2024)',
+    filename: 'mtgo-vintage-cube-nov-2024.json',
+  },
+}
+const DEFAULT_LIST_ID = 'vintage-cube'
+
+const loadedLists = new Map<string, CardEntry[]>()
+for (const [id, { filename }] of Object.entries(LIST_REGISTRY)) {
+  const file = Bun.file(`./cardlists/${filename}`)
+  loadedLists.set(id, await file.json())
+}
+```
+
+`Bun.file(...).json()` parses the JSON array directly — no `.text()` + `.split('\n')`.
+All lists are available before the server begins accepting connections. Additional lists
+are registered by adding an entry to `LIST_REGISTRY` and placing the JSON file in
+`cardlists/`.
+
+### 2. `getRandomCards()` (currently `index.ts:20-29`)
+
+Signature changes from `(requiredNum: number, names: string[])` to
+`(requiredNum: number, entries: CardEntry[]): CardEntry[]`. Deduplication uses a `Map`
+keyed on `entry.name` to preserve full entry objects:
+
+```ts
+function getRandomCards(requiredNum: number, entries: CardEntry[]): CardEntry[] {
+  const chosen = new Map<string, CardEntry>()
+  while (chosen.size < requiredNum) {
+    const randomIndex = Math.floor(Math.random() * entries.length)
+    const entry = entries[randomIndex]
+    chosen.set(entry.name, entry)
+  }
+  return [...chosen.values()]
+}
+```
+
+### 3. `createNewGame()` (currently `index.ts:33-93`)
+
+Gains a `listId: string` parameter. The entry list resolves from `loadedLists`; the card
+loop and `BoardSpace` literal change as follows:
+
+- Line 35 (`getRandomCards(25, cardnamesArray)`) becomes
+  `getRandomCards(25, loadedLists.get(listId)!)`. The `!` is safe because the caller has
+  already validated `listId` against the registry.
+- The `for...of` loop iterates `CardEntry` objects. `card.name` replaces `card` as the
+  word source.
+- The `BoardSpace` literal (`index.ts:68-72`) gains `imageUrl`:
+
+```ts
+const space: BoardSpace = {
+  word: card.name,
+  identity,
+  flipped: false,
+  imageUrl: card.imageUrl,
+}
+```
+
+No other changes inside `createNewGame()`.
+
+### 4. `createNewGame` action handler (currently `index.ts:282-286`)
+
+```ts
+if (action === 'createNewGame') {
+  const listId: string = parsedMsg.listId ?? DEFAULT_LIST_ID
+  if (parsedMsg.listId !== undefined && !LIST_REGISTRY[listId]) {
+    console.error(`createNewGame: unknown listId "${listId}"`)
+    return
+  }
+  if (!parsedMsg.listId) {
+    console.warn(`createNewGame: no listId supplied, falling back to "${DEFAULT_LIST_ID}"`)
+  }
+  createNewGame(listId)
+  console.log('a new game has been created')
+  server.publish('game', JSON.stringify(state))
+}
+```
+
+The `server.publish` call is unchanged.
+
+## Frontend changes — `client/`
+
+### `client/src/lib/gameState.svelte.ts` (line 63-67)
+
+`createNewGame` gains a `listId` parameter:
+
+```ts
+export function createNewGame(listId: string) {
+  const wsConnection = getWsConnection()
+  if (!wsConnection) return
+  wsConnection.send(JSON.stringify({ action: 'createNewGame', listId }))
+}
+```
+
+### `client/src/routes/+page.svelte`
+
+1. **Add `LIST_OPTIONS` and `selectedListId`** to the `<script>` block. This mirrors
+   `LIST_REGISTRY` as a client-side literal (decision 6):
+
+```ts
+const LIST_OPTIONS = [
+  { id: 'vintage-cube', label: 'MTGO Vintage Cube (Nov 2024)' },
+] satisfies { id: string; label: string }[]
+
+let selectedListId = $state(LIST_OPTIONS[0].id)
+```
+
+2. **Add a `<select>` dropdown** in the `{#if gameState.game === null || isGameOver()}`
+   branch (currently lines 24-33), adjacent to the "Create game" button:
+
+```svelte
+<select bind:value={selectedListId}>
+  {#each LIST_OPTIONS as opt (opt.id)}
+    <option value={opt.id}>{opt.label}</option>
+  {/each}
+</select>
+<button onclick={createNewGameAndEnter}>Create game</button>
+```
+
+3. **Update `createNewGameAndEnter`** (line 17-20) to forward the selection:
+
+```ts
+async function createNewGameAndEnter() {
+  createNewGame(selectedListId)
+  await enterGame()
+}
+```
+
+The import on line 2 (`import { gameState, createNewGame, isGameOver } from
+'$lib/gameState.svelte'`) is unchanged — only the call site gains the argument.
+
+No other client files change for this spec. How `imageUrl` is rendered on the board is
+deferred to `specs/card-image-view.md` (issue #18).
+
+## Relationship to other specs
+
+- **`specs/card-image-view.md` (future, issue #18):** that spec will consume
+  `BoardSpace.imageUrl` to render card images in `board.svelte` and related components.
+  This spec only establishes the field and guarantees it is present on every `BoardSpace`;
+  all rendering decisions are out of scope here.
+- **`specs/multi-room.md`:** when rooms land, `createRoom`/`createNewGame` per-room will
+  naturally carry `listId` — one extra field on a message already being extended. Nothing
+  in this spec conflicts with that refactor.
+- **Issue #16 (backend validation/Zod):** `parsedMsg.listId` is exactly the kind of
+  incoming client string that Zod adoption would validate declaratively. For now the
+  registry lookup is the validator (consistent with today's hand-rolled style); the
+  field's name and type (`string | undefined`) are chosen to be trivially Zod-schemable
+  later.
+- **`specs/players-teams-roles.md`:** no interaction. `imageUrl` on `BoardSpace` is
+  equally visible to spymasters and operatives (decision 10) and does not touch the
+  redaction model that spec introduces via ADR 0001.
+
+## Out of scope
+
+- **User-pasted or user-uploaded custom lists.** Only files registered in `LIST_REGISTRY`
+  are accessible; there is no mechanism for clients to supply an arbitrary filename or
+  JSON blob.
+- **Auto-discovery of list files from `cardlists/`.** The directory is not scanned at
+  startup; new files must be explicitly added to `LIST_REGISTRY`.
+- **Runtime Scryfall API calls.** `imageUrl` values are populated offline at
+  list-authoring time and stored in the JSON file. The server never contacts Scryfall
+  during `createNewGame()` or at any other time.
+- **A "list available lists" message from server to client.** The client hardcodes the
+  same values (decision 6). A future spec could add a `listRegistry` field on the initial
+  `login` response if dynamic discovery becomes desirable.
+- **Client-side image rendering.** `imageUrl` is now on every `BoardSpace` the client
+  receives, but when and how images are shown on the board is entirely deferred to
+  `specs/card-image-view.md`.
+- **Redaction of `imageUrl`.** Image URLs do not reveal card identity and require no
+  per-role filtering (decision 10).
+- **Migrating the existing `.txt` file.** Converting `mtgo-vintage-cube-nov-2024.txt` to
+  `.json` with real Scryfall URLs is a list-authoring task, not a code task. Until the
+  migrated file exists, development can use a short hand-crafted fixture (see
+  Verification below).
+
+## Verification
+
+1. **Create a fixture list.** Write a minimal `cardlists/mtgo-vintage-cube-nov-2024.json`
+   with 30+ entries of the shape `{ "name": "Benevolent Bodyguard", "imageUrl":
+   "https://cards.scryfall.io/normal/front/..." }` (real or placeholder URLs). Register
+   it as `'vintage-cube'` in `LIST_REGISTRY`.
+
+2. **Optionally register a second list** (`'sample-cube'`, pointing at a second fixture
+   JSON file) to exercise the multi-list path end-to-end.
+
+3. **Run backend and client:** `bun run index.ts` (port 3000); `cd client && vite dev`.
+   Confirm no startup errors (all registered files load successfully).
+
+4. **Dropdown appears:** on the home page, confirm the `<select>` element lists each
+   registered list by display name. If only one list is registered, the dropdown still
+   renders (with one option).
+
+5. **Create a game with each list:** select each option in turn, click "Create game",
+   navigate to the board. Inspect `gameState.game.board` in the browser — confirm (a) card
+   words come from the chosen list's entries and (b) each `BoardSpace` has a non-empty
+   `imageUrl` string.
+
+6. **Reject invalid `listId`:** send `{"action":"createNewGame","listId":"not-a-real-list"}`
+   directly via WebSocket. Confirm the server logs `console.error` and does **not**
+   broadcast a new game state. Confirm the server does not crash.
+
+7. **Backward-compat default:** send `{"action":"createNewGame"}` (no `listId`). Confirm
+   the server logs `console.warn`, falls back to `DEFAULT_LIST_ID`, and creates a valid
+   game using that list.
+
+8. `cd client && bun run check` — no TypeScript errors on the updated `BoardSpace`
+   interface or the updated `createNewGame(listId: string)` call signature.

--- a/specs/game-logs.md
+++ b/specs/game-logs.md
@@ -1,0 +1,274 @@
+# Spec: Game logs
+
+## Context
+
+Resolves #15, "Add game logs" — *"It would be nice to see all the previous actions in
+the game."* Today the server has no memory of what happened earlier in a game: every
+action (`index.ts:264-320`) mutates the single `state.game` in place and broadcasts the
+resulting snapshot, but nothing records the *sequence* of clues, guesses, and turn
+changes that produced that snapshot. A player who looks away for a moment, or joins
+partway through, has no way to see what already happened — only the current `details`
+(which itself gets overwritten by the next action).
+
+This spec adds a server-maintained **history** of log entries to the existing single
+global game, broadcast alongside the rest of `GameBaseState` on the existing
+`server.publish('game', ...)` channel, and rendered as a simple chronological list in the
+client. Like [`specs/players-teams-roles.md`](./players-teams-roles.md) and
+[`specs/multi-room.md`](./multi-room.md), this is written as a buildable increment on
+today's one-game, no-rooms, no-player-identity architecture — see
+[`CONTEXT.md`](../CONTEXT.md) for the Team/Agent/Emrakul glossary used below.
+
+No ADR is needed: this is additive (a new array on `GameBaseState`, populated at existing
+mutation sites) and doesn't change any existing message shape, authority model, or
+transport decision.
+
+## Decisions
+
+1. **What gets logged — one entry per state-changing player action, not per connection
+   event.** `login` (`index.ts:275-280`) is purely a per-socket handshake (it doesn't
+   touch `state.game`) and is **not** logged. The other five actions each produce exactly
+   one entry:
+   - `createNewGame` (`index.ts:282-286`) → a `gameCreated` entry recording which team goes
+     first (`state.game.currentTurn`, set in `createNewGame()` at `index.ts:36`).
+   - `startGame` (`index.ts:288-292`) → a `gameStarted` entry (no extra data beyond a
+     timestamp; the starting team is already in the preceding `gameCreated` entry).
+   - `submitClue` (`index.ts:294-300`) → a `clueGiven` entry capturing the team that clued
+     (`state.game.currentTurn` *before* `handleClueSubmission` runs — clueing doesn't change
+     `currentTurn`) and the clue itself (`parsedMsg.clue.word`, `parsedMsg.clue.number`).
+   - `guessCard` (`index.ts:308-316`) → a `cardGuessed` entry. Built **after**
+     `guessCard()` mutates state, so it can report the now-`flipped` card's true identity
+     and the outcome. Captures: the guessing team (the `currentTurn` *at the time of the
+     guess*, captured before the call, since a wrong guess flips `currentTurn` inside
+     `guessCard()` — see decision 3 below for why this is safe to log), the card's word and
+     board position (`parsedMsg.position`, `parsedMsg.name` — already validated against
+     each other inside `guessCard()`, `index.ts:117-120`), the revealed `identity`, and
+     whether it was a hit for the guessing team, a hit for the opposing team, neutral, or
+     Emrakul (derived the same way `guessCard()` itself branches at `index.ts:130-199`).
+   - `passTurn` (`index.ts:302-306`) → a `turnPassed` entry capturing the team that passed
+     (`state.game.currentTurn` *before* `handlePassTurn()` flips it at `index.ts:238`).
+
+   Game-over is **not** a separate action — it's a `details.status` produced inside
+   `guessCard()` (`gameOverEmrakul` / `gameOverAgents`, `index.ts:135-138, 146-151,
+   184-189`). The `cardGuessed` entry's `outcome` field carries this (see Domain model
+   below), so there's no separate "game over" log entry — the guess that ended the game is
+   the entry that explains why.
+
+2. **One discriminated union, not optional fields.** `LogEntry` is a union tagged by a
+   `type` field, one variant per bullet above (`GameCreatedLogEntry`,
+   `GameStartedLogEntry`, `ClueGivenLogEntry`, `CardGuessedLogEntry`,
+   `TurnPassedLogEntry`). This mirrors the existing `Details` union in
+   `shared/types.ts:76-86` (also tagged by `status`), keeps each entry's fields required
+   instead of a pile of optionals, and lets the client `{#each}` over entries with a
+   `{#if entry.type === ...}` switch exactly like `gameInfoSection.svelte` already
+   switches on `details.status` (`gameInfoSection.svelte:31-99`).
+
+3. **History piggybacks on the existing full-state broadcast — no new message type.**
+   Every action that mutates `state.game` already calls
+   `server.publish('game', JSON.stringify(state))` (`index.ts:285, 291, 299, 305, 315`).
+   `history` becomes a field on `GameBaseState` itself, so it rides along for free: append
+   the new entry to `state.game.history` *before* the existing `server.publish` call at
+   each site, and nothing about the transport changes. No new client message handler,
+   no new pub/sub topic, no redaction logic to write.
+
+   **On secrecy:** a `cardGuessed` entry only exists *after* `guessCard()` has already set
+   `targetCard.flipped = true` (`index.ts:128`) and the full board — including that card's
+   real `identity` — is already part of the very same broadcast that carries the log entry
+   (the board is part of `state.game`, sent in the same `JSON.stringify(state)`). A log
+   entry never describes an *unflipped* card's identity; it only ever restates something
+   the broadcast itself just made public. So logging revealed identities adds no new leak
+   today, and (per ADR 0001) will need no special handling later either: once the server
+   redacts unflipped identities from the *board*, a `cardGuessed` entry is still only ever
+   created for a card that has just been flipped, i.e. one whose identity the redacted
+   broadcast is, at that same moment, no longer hiding from anyone. The one piece of
+   future-facing care called out for the ADR 0001 work: don't let a *clue* itself leak
+   into history in a way that exposes the spymaster's key — this spec's `clueGiven` entry
+   only stores the clue word/number actually spoken aloud (already visible to everyone,
+   spymaster and operatives alike, today), never the underlying key, so it carries no
+   additional risk.
+
+4. **Render as a reverse-chronological panel, newest entry first**, in a new
+   `gameLog.svelte` component. One line of plain text per entry (team-colored team name,
+   same convention as `InlineTeamLogo`), no avatars/timestamps in the UI (a `createdAt`
+   field exists in the data for future use but isn't displayed in v1).
+
+5. **Unbounded history for the life of one game.** No cap. A game's board is 25 cards;
+   even a long game produces on the order of tens of entries (≤25 guesses + a handful of
+   clues/passes), each a few dozen bytes — negligible next to the board itself. This
+   matches the "memory is not the bottleneck" reasoning in
+   [`specs/multi-room.md`](./multi-room.md#scalability--the-single-server-in-memory-model):
+   the in-memory game state already lives for free until `createNewGame` replaces it
+   (`index.ts:92`), at which point `history` resets along with everything else.
+
+## Domain model — `shared/types.ts`
+
+```ts
+interface LogEntryBase {
+  id: string // crypto.randomUUID(), for stable Svelte #each keys
+  createdAt: number // Date.now(), not rendered in v1, reserved for later use
+}
+
+export interface GameCreatedLogEntry extends LogEntryBase {
+  type: 'gameCreated'
+  firstTeam: Team
+}
+
+export interface GameStartedLogEntry extends LogEntryBase {
+  type: 'gameStarted'
+}
+
+export interface ClueGivenLogEntry extends LogEntryBase {
+  type: 'clueGiven'
+  team: Team
+  clue: { word: string; number: string | null }
+}
+
+export interface CardGuessedLogEntry extends LogEntryBase {
+  type: 'cardGuessed'
+  team: Team // the team that guessed
+  word: string
+  position: [number, number]
+  identity: CardIdentity // the revealed identity
+  outcome: 'ownAgent' | 'opposingAgent' | 'neutral' | 'emrakul'
+}
+
+export interface TurnPassedLogEntry extends LogEntryBase {
+  type: 'turnPassed'
+  team: Team // the team that passed
+}
+
+export type LogEntry =
+  | GameCreatedLogEntry
+  | GameStartedLogEntry
+  | ClueGivenLogEntry
+  | CardGuessedLogEntry
+  | TurnPassedLogEntry
+```
+
+- `GameBaseState` (`shared/types.ts:88-96`) gains a `history: LogEntry[]` field, initialized
+  to `[]` in `createNewGame()` and appended to (never replaced) by every other action.
+- `outcome` on `CardGuessedLogEntry` is derived, not stored redundantly with
+  `details.status` — it's computed once at the `guessCard` call site (see below) from the
+  same branches `guessCard()` already evaluates, so the log doesn't need to re-derive
+  anything `index.ts` doesn't already know at that point.
+
+## Backend changes — `index.ts`
+
+1. **`createNewGame()` (`index.ts:33-93`):** initialize `history: []` in the `game` object
+   literal (`index.ts:80-91`), then immediately push a `gameCreated` entry
+   (`{ type: 'gameCreated', firstTeam: currentTurn, id: crypto.randomUUID(), createdAt:
+   Date.now() }`) — `currentTurn` is already computed at `index.ts:36`.
+
+2. **`startGame()` (`index.ts:95-104`):** after setting `details`, push a `gameStarted`
+   entry onto `state.game.history`.
+
+3. **`handleClueSubmission(clue)` (`index.ts:202-225`):** capture `state.game.currentTurn`
+   into a local before mutating `details` (it isn't changed by this function, but doing so
+   keeps the pattern consistent with `guessCard`/`handlePassTurn` below and guards against
+   future changes), then push a `clueGiven` entry with that team and the `clue` parameter
+   (already validated non-empty at `index.ts:208`).
+
+4. **`guessCard(position, name)` (`index.ts:107-200`):** capture `currentTeam` (already a
+   local at `index.ts:126`) before any mutation. At each of the four outcome branches
+   (Emrakul `index.ts:130-140`; own-team hit `index.ts:142-170`; neutral `index.ts:172-180`;
+   opposing-team hit `index.ts:182-199`), push one `cardGuessed` entry with `team:
+   currentTeam`, `word: name`, `position`, `identity: targetCard.identity`, and the
+   matching `outcome` (`'emrakul'`, `'ownAgent'`, `'neutral'`, `'opposingAgent'`
+   respectively) before each early `return`. Since every branch returns, exactly one entry
+   is ever pushed per call — simplest to add the push as the first line of each branch
+   right after `targetCard.flipped = true` is set (`index.ts:128`), since `identity` is
+   already known by then regardless of which branch is about to run.
+
+5. **`handlePassTurn()` (`index.ts:227-239`):** capture `state.game.currentTurn` *before*
+   the reassignment at `index.ts:238`, push a `turnPassed` entry with that team.
+
+6. **No changes to the `message` handler's `server.publish` calls** (`index.ts:285, 291,
+   299, 305, 315`) — `history` is just another field on the already-published `state`.
+
+## Frontend changes — `client/`
+
+1. **New `client/src/lib/gameLog.svelte`:** takes no props (reads `gameState` directly,
+   same convention as `gameInfoSection.svelte`). Renders
+   `gameState.game?.history` reversed (`.slice().reverse()`) inside a scrollable list,
+   `{#each ... (entry.id)}`, with an `{#if entry.type === ...}` per variant producing a
+   single line of text, e.g.:
+   - `gameCreated` → "New game started — `<InlineTeamLogo identity={entry.firstTeam} />`
+     goes first."
+   - `gameStarted` → "The game has started."
+   - `clueGiven` → "`<InlineTeamLogo identity={entry.team} />` spymaster clued
+     **{entry.clue.word}** ({entry.clue.number})."
+   - `cardGuessed` → "`<InlineTeamLogo identity={entry.team} />` guessed **{entry.word}**
+     — " plus one of: "a `<InlineTeamLogo identity={entry.team} />` agent." (ownAgent),
+     "a `<InlineTeamLogo identity={getOpposingTeam(entry.team)} />` agent."
+     (opposingAgent), "a neutral card." (neutral), or "Emrakul!" (emrakul) — reusing
+     `InlineTeamLogo` (`client/src/lib/inlineTeamLogo.svelte`) the same way
+     `gameInfoSection.svelte` does throughout.
+   - `turnPassed` → "`<InlineTeamLogo identity={entry.team} />` passed the turn."
+
+2. **Placement:** render `<GameLog />` from `client/src/routes/game/+page.svelte` and
+   `client/src/routes/game/spymaster/+page.svelte`, alongside `<GameInfoSection />` and
+   `<Board />` (both files already follow the identical `{#if gameState.game ===
+   null}...{:else if ...gameReady}<GameReadyScreen />{:else}...{/if}` shape — add
+   `<GameLog />` in the final `{:else}` branch of both, e.g. right after `<Board />` in
+   `client/src/routes/game/+page.svelte:13-15` and
+   `client/src/routes/game/spymaster/+page.svelte:58`). No log during `gameReady`
+   (nothing has happened yet beyond `gameCreated`, which isn't worth surfacing before the
+   player even sees the board) — optional follow-up, not blocking.
+
+3. **`client/src/lib/gameState.svelte.ts`:** no changes needed. `history` arrives as part
+   of the existing `gameState.game` object already assigned in `onmessage`
+   (`gameState.svelte.ts:45-48`); no new action senders, no new message branch.
+
+4. **Types:** the component imports `LogEntry` (and the per-variant types it needs to
+   narrow on) from `../../../shared/types`, same import path used elsewhere
+   (`board.svelte:2`, `gameInfoSection.svelte:3`).
+
+## Relationship to other specs
+
+- **[`specs/players-teams-roles.md`](./players-teams-roles.md):** once Players exist,
+  entries could optionally attribute actions to a `playerId`/name rather than just a
+  `Team` (e.g. "Alice (Mirran spymaster) clued ISLAND"). Not required by this spec —
+  `team` alone is sufficient today since there's no player identity to attach. When that
+  spec lands, extending each variant with an optional `playerName`/`playerId` is a small,
+  additive follow-up; this spec deliberately doesn't speculate further on that shape.
+- **[`specs/multi-room.md`](./multi-room.md):** composes trivially. `history` lives on
+  `GameBaseState`, and that spec's refactor moves `GameBaseState` from the single global
+  `state.game` into a per-room map — `history` just rides along as a field on whichever
+  object represents "the room's game," with no special-casing needed.
+- **ADR 0001 (server-authoritative redacted state):** as argued in Decision 3, log entries
+  never need redaction — they're only ever created for already-public, already-flipped
+  information. No follow-up work is anticipated here when that ADR is implemented, beyond
+  double-checking (in review, not in code) that no future log-entry type is added for an
+  action that exposes *unflipped* identities.
+
+## Out of scope
+
+- **Persistence across server restarts.** `history` lives in memory exactly like the rest
+  of `GameBaseState` and is lost on restart or `createNewGame` — consistent with this
+  project's no-persistence stance (see `specs/multi-room.md`'s Out of scope and ADR 0002).
+- **Exporting, sharing, or copying the log** (e.g. a "copy log to clipboard" button).
+- **Replay or undo from the log.** The log is read-only history, not a mechanism for
+  rewinding game state.
+- **Capping/pagination.** Per Decision 5, unbounded for one game's lifetime; revisit only
+  if a future change makes games meaningfully longer-lived (e.g. a "best of N" mode).
+- **Per-room scoping.** Doesn't exist yet because rooms don't exist yet (see Relationship
+  to other specs above); nothing here blocks `multi-room.md` from adding it later.
+- **Attributing entries to individual players** rather than teams — blocked on
+  `specs/players-teams-roles.md` landing first; see Relationship to other specs.
+
+## Verification
+
+1. Run the backend (`bun run index.ts`, port 3000) and client (`cd client && vite dev`).
+2. **Entries appear in order:** create a game, start it, submit a clue, guess a correct
+   card, guess an incorrect card, pass the turn — confirm `gameLog.svelte` shows one new
+   line per action, newest first, with the right team names and words.
+3. **Game-over entry:** play (or rig, by guessing Emrakul) until the game ends — confirm
+   the final `cardGuessed` entry's wording matches the actual outcome (Emrakul loss vs.
+   last-agent win) without needing a separate "game over" line.
+4. **Survives reconnect:** open a second browser window mid-game — confirm it receives the
+   full `history` array (not just entries created after it joined), since the whole
+   `GameBaseState` (including `history`) is sent on every broadcast.
+5. **Resets correctly:** after game-over, click "Reset and create new game" — confirm the
+   log clears down to just the new `gameCreated` entry, not a continuation of the previous
+   game's history.
+6. `cd client && bun run check` for type-safety on the new `LogEntry` union and the
+   `gameLog.svelte` component's narrowing.

--- a/specs/multi-room.md
+++ b/specs/multi-room.md
@@ -1,0 +1,195 @@
+# Spec: Support multiple game rooms
+
+## Context
+
+`mtg-codenames` is a Codenames game (Bun WebSocket backend + SvelteKit client) that
+currently supports **only one game at a time**. This isn't a deliberate feature — it's
+baked into the backend:
+
+- `index.ts:9` holds a single module-level `state: GameState = { game: null }`. Every
+  game-logic function (`createNewGame`, `guessCard`, `handleClueSubmission`,
+  `handlePassTurn`, `startGame`) mutates that one object via closure.
+- Every socket subscribes to the same pub/sub topic `'game'` (`index.ts:258`), and every
+  action calls `server.publish('game', ...)`, so all clients always see the same game.
+- The client never sends a room identifier (`gameState.svelte.ts`).
+
+**Goal:** let many independent games run at once, keyed by a short shareable **room code**,
+so different groups can play simultaneously. The game rules, `Details` status
+state-machine, and board rendering stay untouched — this only changes *which* game a given
+socket talks to.
+
+**Decisions (confirmed with user):**
+- Room code lives in the **URL** for shareable links + survives refresh; also joinable by
+  typing the code. Routes restructure to `/game/[roomCode]`.
+- Rooms are **deleted when the last player leaves** (per-room socket count → 0).
+- **4-letter codes** (e.g. `WXYZ`), with a collision check against existing rooms.
+
+## Backend changes — `index.ts`
+
+1. **Replace the single global with a room map.**
+   - `const rooms = new Map<string, GameBaseState | null>()` replacing `state`.
+   - Add a per-room connection counter for cleanup, e.g.
+     `const roomConnections = new Map<string, number>()`.
+
+2. **Refactor game-logic functions to operate on a passed-in game**, not the global
+   closure. Each of `createNewGame`, `startGame`, `guessCard`, `handleClueSubmission`,
+   `handlePassTurn` should take/return the relevant room's `GameBaseState` (or accept a
+   `roomCode` and read/write `rooms`). `createNewGame` returns a fresh `GameBaseState`
+   that the caller stores under the code; the others mutate `rooms.get(code)`.
+
+3. **Room code generation.** Add `generateRoomCode()` → 4 uppercase letters, re-rolling on
+   collision with `rooms.has(code)`.
+
+4. **New/changed actions** (all action messages now carry `roomCode`, except creation):
+   - `createRoom` — generate a code, create a game, store it, send the code back to the
+     creator (`{ roomCode }`), subscribe that socket to the `roomCode` topic.
+   - `joinRoom` — given a `roomCode`, if the room exists subscribe the socket to that topic
+     and send that room's current state; otherwise send a "room not found" response.
+   - `createNewGame`, `startGame`, `submitClue`, `passTurn`, `guessCard` — read
+     `parsedMsg.roomCode`, mutate that room, and `server.publish(roomCode, ...)` instead of
+     the global `'game'` topic.
+
+5. **Per-connection room tracking + cleanup** using `socket.data`:
+   - In `message`/`joinRoom`/`createRoom`: set `socket.data = { roomCode }`, call
+     `socket.subscribe(roomCode)`, and increment `roomConnections`.
+   - In `close(socket)`: read `socket.data.roomCode`, `unsubscribe`, decrement the counter,
+     and when it hits 0 delete both `rooms` and `roomConnections` entries.
+   - Remove the unconditional `socket.subscribe('game')` from `open` (subscription now
+     happens on create/join).
+
+   Note: Bun's `Bun.serve` needs the `websocket.data` type set (or cast) so `socket.data`
+   is typed — define a small `type SocketData = { roomCode?: string }`.
+
+## Frontend changes — `client/`
+
+1. **Restructure routes** so the room code is in the URL:
+   - Move `client/src/routes/game/+page.svelte` → `game/[roomCode]/+page.svelte`.
+   - Move `game/spymaster/+page.svelte` → `game/[roomCode]/spymaster/+page.svelte`.
+   - Move `game/new/+page.svelte` → `game/[roomCode]/new/+page.svelte`.
+   - Read the code via `$page.params.roomCode` (or a `load`) and pass it into the
+     gameState action calls.
+
+2. **Home page — `client/src/routes/+page.svelte`:**
+   - "Create room" → send `createRoom`, await the returned code, then
+     `goto('/game/' + code)`.
+   - "Join room" → text field for a 4-letter code → `goto('/game/' + code)`.
+
+3. **`client/src/lib/gameState.svelte.ts`:**
+   - Track the active `roomCode` (set when a page mounts with a param, or returned from
+     `createRoom`).
+   - Include `roomCode` in every outgoing message (`startGame`, `passTurn`, `submitClue`,
+     `guessCard`, plus a new `createRoom`/`joinRoom`).
+   - On entering a room page, send `joinRoom` with the code so this socket subscribes to the
+     right topic and receives that room's state. Handle the creator flow (capture the
+     returned code) and a "room not found" response (route back home / show a message).
+
+4. **Shared types — `shared/types.ts`:** optionally add a `RoomCreatedResponse`
+   (`{ roomCode: string }`) and/or `RoomNotFound` message type so client and server agree on
+   the new non-game-state messages. The client's `isGameState` guard already ignores
+   non-game-state messages, so these need their own branch in `onmessage`.
+
+## Hosting
+
+Two deployable pieces:
+
+- **Backend (Bun WS server):** needs a host with a long-lived process and WebSocket
+  support — Render (the `client/.env` already has a commented `wss://` Render URL),
+  Railway, or Fly.io. Single container, `bun run index.ts`, listening on port 3000.
+  ⚠️ **Free tiers (incl. Render free) spin the process down after ~15 min idle**, which
+  cold-starts the server *and erases every in-memory room*. A real deployment wants a
+  paid always-on instance.
+- **Frontend (SvelteKit, `adapter-auto`):** static/SSR — deploy to Vercel / Netlify /
+  Cloudflare Pages, or alongside the backend. Set `PUBLIC_BACKEND_URL` to the `wss://`
+  backend URL in the hosting env.
+
+## Scalability & the single-server in-memory model
+
+The room map lives in **one process's RAM**. Honest assessment of the trade-offs:
+
+- **Memory is *not* the bottleneck.** A room is a 25-card board + status — a few KB.
+  Even ~10,000 concurrent rooms is only tens of MB. Other limits bind first.
+- **Single point of failure (biggest risk):** a crash, redeploy, or free-tier sleep
+  wipes **all active games instantly**, mid-play. No persistence, no recovery.
+- **No horizontal scaling (hard ceiling):** WebSocket connections and `server.publish`
+  are **per-process**. With 2+ instances behind a load balancer, two players in the same
+  room can land on different instances and never see each other's moves. The design is
+  capped at what **one** Bun process can serve — which is thousands of concurrent
+  connections, likely plenty for this game.
+- **No reconnection logic:** the client's `onclose` only logs (`gameState.svelte.ts:51`).
+  A network blip or server sleep drops players with no auto-rejoin.
+
+**Migration path (only if/when one server isn't enough):** externalize room state and
+pub/sub to **Redis** — Redis pub/sub fans broadcasts across instances; Redis as the room
+store survives restarts. That one change unlocks both horizontal scaling and
+crash-resilience. The action handlers stay the same shape; only the `rooms` map and
+`server.publish` get swapped for Redis calls. Not needed for an MVP single-instance deploy.
+
+A cheaper resilience win short of Redis: add **client reconnect + auto-rejoin** (on
+`onclose`, retry the WS connection and re-send `joinRoom` with the URL's room code) so
+transient drops don't kick players out of a still-running game.
+
+## Removing the single point of failure
+
+A spectrum of fixes, increasing in effort:
+
+1. **Cheapest — survive *transient* drops, not crashes.** Client auto-reconnect (above):
+   on `onclose`, retry the WebSocket and resend `joinRoom` with the URL's code. Doesn't
+   help if the *server* dies, but covers the much more common case of a flaky
+   network/laptop-sleep dropping a player from a still-alive game.
+
+2. **Survive restarts — persist room state externally.** Periodically (or on every
+   mutation) write each room's `GameBaseState` to something outside the process — Redis,
+   a SQLite file, or a managed KV store. On boot, reload any rooms with recent activity.
+   Fixes "deploy wiped my game" without solving horizontal scaling. Redis is the natural
+   choice since it gives persistence *and* pub/sub fan-out in one step (see #3).
+
+3. **Real fix — Redis as shared state + pub/sub.** This is the one that actually removes
+   the SPOF rather than patching around it:
+   - **Room state** moves from the in-memory `Map` to Redis (a hash or JSON blob per room
+     code). Any instance can read/write any room.
+   - **Broadcast** moves from `server.publish(topic, ...)` to Redis pub/sub — each Bun
+     instance subscribes to the Redis channels for the rooms it has local sockets for, and
+     republishes to its own local `server.publish`. This is the standard "Socket.IO Redis
+     adapter" pattern.
+   - This unlocks running **multiple Bun instances** behind a load balancer correctly, and
+     a single instance crashing no longer loses any room — Redis still has it, other
+     instances keep serving.
+   - Cost: Redis itself becomes a dependency, but managed Redis (Upstash, Render's own
+     Redis, Railway) has far better availability guarantees than a single hobby web
+     service, and it's a well-understood SPOF to manage (replicas, AOF persistence).
+
+4. **Belt-and-suspenders — health checks + auto-restart.** Configure the host
+   (Render/Railway/Fly) to auto-restart the process on crash. Combined with #2/#3, a crash
+   becomes a few-second blip instead of data loss.
+
+**Recommendation:** for this project's scale, skip straight to **Redis (#2+#3 combined)**
+if the goal is to genuinely solve the SPOF — it's barely more work than a
+persistence-only layer and future-proofs horizontal scaling at the same time. If the goal
+is just resilience against a free-tier instance sleeping/restarting without touching
+infra, **#1 + #2 (Redis as a persistence-only store, single instance)** is the lighter
+lift.
+
+## Out of scope (not requested)
+- Listing/browsing active rooms (lobby).
+- Per-player identity / team membership (the stubbed `login` + `// add logged in users`
+  TODO stays as-is).
+- Persistence across server restarts (rooms remain in-memory).
+
+## Verification
+
+1. **Run both apps:** backend `bun run index.ts` (port 3000); client `cd client && vite dev`.
+   Confirm `client/.env` `PUBLIC_BACKEND_URL="ws://localhost:3000"`.
+2. **Two-room isolation:** open two browser windows. In window A click "Create room", note
+   the code/URL, create + start a game, flip a card. In window B create a *different* room
+   and confirm its board is independent (different cards, A's flips don't appear).
+3. **Join flow:** copy window A's `/game/XXXX` URL into a third window (or type the code on
+   the home page) — it should load A's current game and stay in sync (flip a card in A, see
+   it in the third window).
+4. **Refresh:** reload a `/game/XXXX` page and confirm it rejoins the same room and shows
+   current state.
+5. **Cleanup:** close all windows for a room, then re-join its code — should report "room
+   not found" (game was deleted at zero connections). Check server logs for the
+   create/join/close lifecycle.
+6. **Unknown code:** navigate to `/game/ZZZZ` for a non-existent room → graceful
+   "room not found" handling, no crash.
+7. `cd client && bun run check` for type-safety on the new params/messages.

--- a/specs/players-teams-roles.md
+++ b/specs/players-teams-roles.md
@@ -1,0 +1,154 @@
+# Spec: Players, Teams & Roles (the "login" feature)
+
+## Context (problem)
+
+Today the game has no concept of *who* is playing:
+- **Team** (`mirran`/`phyrexian`) is only a card identity + `currentTurn`; no player belongs to a team.
+- **Role** (spymaster/operative) is a pure client-side view flag (`spymasterView`,
+  `gameReadyScreen.svelte:10`); you "become" a spymaster just by visiting `/game/spymaster`
+  (`gameReadyScreen.svelte:99`). The two views are two hardcoded routes that pass
+  `spymasterView` (`routes/game/+page.svelte`, `routes/game/spymaster/+page.svelte`).
+- `login` is a stub (`index.ts:275`) that echoes state with a throwaway UUID. `GameBaseState`
+  carries the TODO `// add logged in users and users by team` (`types.ts:95`).
+- **No enforcement & no secrecy:** the full board (every identity) is broadcast to everyone via
+  `server.publish('game', ...)`; the *client* hides identities for operatives
+  (`board.svelte:36`). So any operative can open `/game/spymaster` and read the whole key.
+
+**Goal:** assign Players to Teams and Roles, server-side, and enforce them — turning the
+stubbed `login` TODO into a real (account-less) identity + lobby system.
+
+See [`CONTEXT.md`](../CONTEXT.md) for the Player/Team/Role/Agent/Lobby glossary.
+
+## Decisions
+
+1. **Server enforces integrity rules.** Only the current team's spymaster may submit a clue;
+   only the current team's operatives may guess; operatives never receive the key.
+2. **Identity: server-issued token in `localStorage`.** On first join the server mints
+   `{ playerId, token }`; client stores it and re-presents it to reclaim the same seat on
+   refresh/reconnect. No accounts.
+3. **Self-select Team and Role** in a lobby; server enforces constraints.
+4. **Exactly one spymaster per Team, exclusive** (first-come locks the seat); unlimited operatives.
+5. **Start gated on composition:** each Team must have its spymaster seat filled **and** ≥1
+   operative. Any Player may press Start once valid.
+6. **Disconnect: hold the seat, allow takeover if vacated.** Reconnect-by-token reclaims it;
+   UI flags a disconnected Player; a teammate can explicitly take over a vacated role so a
+   gone-for-good spymaster never bricks the game.
+7. **Server-authoritative redacted state** (see ADR 0001): operatives receive a board with no
+   identities on **unflipped** cards; only spymasters get the full key. Flipped cards are public
+   to all. Replaces the single broadcast with per-role tailored state.
+8. **Players have display names**, prompted on join (blank → auto fallback like `Player-AB12`).
+9. **Team/Role locked once the game starts**, except the disconnect-takeover in (6).
+
+## Domain model — `shared/types.ts`
+
+```ts
+export type Role = 'spymaster' | 'operative'
+
+// Server-side (never sent to clients): includes the secret token
+interface ServerPlayer {
+  id: string
+  token: string          // secret; reconnection credential
+  name: string
+  team?: Team            // undefined until chosen (lobby)
+  role?: Role            // undefined until claimed
+  connected: boolean
+}
+
+// Public projection sent in game state (no token)
+export interface Player {
+  id: string
+  name: string
+  team?: Team
+  role?: Role
+  connected: boolean
+}
+
+// Redacted board cell: identity present only when flipped (or for spymasters, always)
+export interface RedactedBoardSpace {
+  word: string
+  flipped: boolean
+  identity?: CardIdentity   // omitted for unflipped cards in the operative view
+}
+```
+- `GameBaseState` gains `players: Player[]` (replacing the `// add logged in users` TODO). The
+  server's working copy holds `ServerPlayer[]`; the public state maps to `Player[]`.
+- The board type the **client** consumes becomes `RedactedBoardSpace[][]` (identity optional).
+  `board.svelte` must render a face-down card when `identity` is absent.
+
+## Backend changes — `index.ts`
+
+1. **Player store per room/game.** Hold `ServerPlayer[]` on the game; map each socket to a
+   player via `socket.data = { playerId }`.
+2. **Identity / join (replaces `login`):** `join { roomCode?, token?, name? }` →
+   - If `token` matches an existing player, re-attach (set `connected=true`, update socket map)
+     — this is the reconnect/refresh path.
+   - Else mint `{ id, token }`, create a `ServerPlayer` (unassigned, in the lobby), and send the
+     token back to that socket so the client can persist it.
+3. **Lobby actions** (pre-game): `setName`, `chooseTeam { team }`, `claimRole { role }`.
+   - `claimRole('spymaster')` fails if the team's spymaster seat is taken (decision 4).
+   - All blocked once `status` has left `gameReady`/lobby (decision 9), except `takeOverRole`.
+4. **`takeOverRole { team, role }`** — mid-game claim of a seat whose holder is `connected=false`
+   (decision 6).
+5. **Enforce on existing actions** (decision 1) using `socket.data.playerId` → player:
+   - `submitClue` — reject unless caller is the **current team's spymaster**.
+   - `guessCard` — reject unless caller is a **current team's operative**.
+   - `startGame` — reject unless composition is valid (decision 5).
+6. **Redacted broadcast** (decision 7) — replace `server.publish('game', fullState)` with two
+   payloads:
+   - **Full** (real identities) → spymasters.
+   - **Redacted** (`RedactedBoardSpace` with unflipped identities stripped) → operatives +
+     unassigned/lobby players.
+   - Mechanism: keep Bun pub/sub but use **two topics per room** —
+     `room:<code>:full` and `room:<code>:redacted`; publish both on every change. A socket is
+     subscribed to exactly one based on its player's current role, re-subscribing when the role
+     changes. (Fallback if topic juggling gets hairy: iterate the room's sockets and
+     `socket.send` a per-socket payload.) Player roster (`players`) is identical in both payloads.
+7. **Disconnect (`close`)** — set `connected=false`, keep the seat, re-broadcast roster. Do **not**
+   release (decision 6).
+
+## Frontend changes — `client/`
+
+1. **Token persistence + identity — `gameState.svelte.ts`:**
+   - Read/write the player token in `localStorage`; send it on `join`; store the returned token.
+   - Track `myPlayer` (id/name/team/role) derived from the roster + my id.
+   - New action senders: `join`, `setName`, `chooseTeam`, `claimRole`, `takeOverRole`.
+   - `onmessage`: handle the token-issued message and the tailored game state (board may now lack
+     identities). The existing `isGameState` guard already ignores non-state messages.
+2. **Lobby / team-select UI** (replaces navigation-based role choice in `gameReadyScreen.svelte`):
+   - Name prompt; two team columns showing the roster (`players` grouped by team) with
+     connected/disconnected indicators; "Join team", "Claim spymaster" (disabled if taken),
+     "Become operative" buttons; a Start button enabled only when composition is valid.
+3. **Role-driven views (collapse the spymaster route):**
+   - `board.svelte` — `spymasterView` becomes `$derived(myPlayer?.role === 'spymaster')` instead of
+     a prop/route; render face-down when `identity` is absent (`board.svelte:36-39`); only show the
+     "Guess card" button to a current-team operative (`board.svelte:41`).
+   - Clue-input form (`routes/game/spymaster/+page.svelte:30-57`) moves into the single game view,
+     shown only to the current team's spymaster.
+   - `routes/game/spymaster/+page.svelte` is **removed**; `/game` renders role-appropriately. (Under
+     the multi-room spec this is `/game/[roomCode]`.)
+
+## Relationship to the multi-room spec
+Composes with [`specs/multi-room.md`](./multi-room.md): a Player belongs to a room, and the
+two-topic redaction layers onto the per-room topics there. Shippable independently — the
+"room" can be today's single global game. The reconnect-by-token here also delivers the client
+auto-rejoin noted in that spec.
+
+## Out of scope
+- Real authentication / accounts / persistence of players across server restarts.
+- Spectators, chat, multiple concurrent spymasters, team auto-balancing.
+- Scoreboards / cross-game player history.
+
+## Verification
+1. Run backend (`bun run index.ts`) + client (`cd client && vite dev`).
+2. **Identity persists:** join, set a name, refresh the page → same seat/name reclaimed (token).
+3. **Self-select + exclusivity:** with 4 browser windows, each picks a team; the 2nd attempt to
+   claim a team's spymaster is rejected (seat shows taken). Confirm rosters match across windows.
+4. **Start gating:** Start is disabled until both teams have a spymaster + ≥1 operative; becomes
+   enabled when satisfied.
+5. **Secrecy (the core win):** as an operative, inspect the WebSocket frames — unflipped cards have
+   **no identity**; the spymaster view does. Flipped cards show identity to everyone.
+6. **Action enforcement:** an operative's `submitClue` is rejected; a non-current-team operative's
+   `guessCard` is rejected; the off-turn spymaster can't clue.
+7. **Disconnect/takeover:** close the spymaster window mid-game → teammates see them disconnected
+   and can take over the role; original can also reconnect (token) to reclaim if not taken.
+8. `cd client && bun run check` for type-safety on the new `Player`/`RedactedBoardSpace` shapes.


### PR DESCRIPTION
This PR adds foundational specification and architecture decision documents that establish the design patterns and constraints for the mtg-codenames project.

## Summary

Added four detailed specification documents and two architecture decision records (ADRs) that define the game's domain language, core features, and technical decisions. These specs serve as the blueprint for upcoming implementation work and establish clear patterns for how the codebase should evolve.

## Key additions

**Specifications:**
- `specs/card-list-selection.md` — Defines support for multiple named card lists (JSON format with image URLs), selectable at game creation via a dropdown. Establishes the `CardEntry` type, `LIST_REGISTRY` whitelist pattern, and eager-loading strategy. Extends `BoardSpace` with a required `imageUrl` field.
- `specs/game-logs.md` — Specifies a server-maintained history of game actions (clues, guesses, passes, game state changes) as a discriminated union of log entry types, broadcast alongside game state. Defines rendering as a reverse-chronological list in the client.
- `specs/multi-room.md` — Describes the architecture for supporting multiple concurrent games via room codes in the URL. Details the room map, connection tracking, cleanup on disconnect, and scalability trade-offs (single-process in-memory model with Redis migration path).
- `specs/players-teams-roles.md` — Establishes the login/identity system: server-issued tokens in localStorage, team/role assignment in a lobby phase, enforcement of action permissions (spymaster clues, operative guesses), and server-authoritative redacted state (operatives don't receive unflipped card identities).

**Architecture Decision Records:**
- `docs/adr/0001-server-authoritative-redacted-state.md` — Justifies why the server must redact unflipped identities before sending to operatives, rather than trusting the client to hide them.
- `docs/adr/0002-account-less-token-identity.md` — Explains the choice of server-minted tokens in localStorage for player identity, avoiding the overhead of a full account system.

**Domain glossary:**
- `CONTEXT.md` — Defines project-specific terminology (Player, Team, Role, Agent, Emrakul, Lobby, Room) to ensure consistent language across specs and code.

## Notable design patterns

- **Whitelist registry pattern** (`LIST_REGISTRY`) for safely loading external data files without path injection.
- **Discriminated union types** for `LogEntry` and `Details` to keep variant fields required and enable exhaustive client-side pattern matching.
- **Per-role state redaction** via dual pub/sub topics (`room:<code>:full` and `room:<code>:redacted`) to enforce server-side secrecy.
- **Backward-compatible defaults** (e.g., missing `listId` falls back to `DEFAULT_LIST_ID`) to survive rolling updates.
- **Eager loading of static data** (card lists) at startup for per-request performance.

All specs are written as buildable increments on the current single-game architecture and include verification steps for testing.

https://claude.ai/code/session_01BKFJYPH4wM1AHPm9V7ZPWW